### PR TITLE
Option to append the picker somewhere else in doc

### DIFF
--- a/js/jquery.datepicker.js
+++ b/js/jquery.datepicker.js
@@ -232,7 +232,7 @@
 			datePicker.append(decades);
 			$.datePicker.hide(true);
 			// Position
-			if (opts.element) {
+			if (opts.element && ! opts.appendTo) {
 				var offset = opts.element.offset();
 				//
 				datePicker.css({
@@ -242,7 +242,7 @@
 			}
 			// Add to DOM
 			datePicker.hide();
-			$('body').append(datePicker);
+			$(opts.appendTo || 'body').append(datePicker);
 			datePicker.fadeIn(150);
 			// Calendar events
 			datePicker.on('click', '.calendar .day', function(e) {


### PR DESCRIPTION
This is usefull when opening the datepicker from a dialog with a different z-index stack context.

Usage:
<div style='position:absolute;z-index:100; top:0;left:0;right:0;width:0'>
   <span id='anchor' style='position:relative'></span>
   <input id='input'>
</div>

$.datepicker.show({
  element : $("#input"),
  appendTo: $("#anchor")
})

